### PR TITLE
AJUSTES: Select com competências da BNCC

### DIFF
--- a/src/Constants/resource-fields.ts
+++ b/src/Constants/resource-fields.ts
@@ -12,6 +12,7 @@ export const RESOURCE_FIELDS = [
   {name:'Recurso correlato' , field: (resource: Resource) => resource?.relation ?? '', property: 'dc.relation'},
   {name:'Ultima modificação na plataforma' , field: (resource: Resource) => resource?.last_modification ? FormatDate(resource?.last_modification) : '', property: 'dc.last_modification'},
   {name:'Tipo de recurso' , field: (resource: Resource) => resource?.type ?? '', property: 'dc.type'},
+  {name:'Competência BNCC' , field: (resource: Resource) => resource?.bncc ?? '', property: 'bncc'},
   {name:'Formato do recurso' , field: (resource: Resource) => resource?.format ?? '', property: 'dc.format'},
   {name:'Linguagem' , field: (resource: Resource) => resource?.language ?? '', property: 'dc.language'},
   {name:'Contribuidores do recurso' , field: (resource: Resource) => resource?.contributor ?? '', property: 'dc.contributor'},

--- a/src/Styles/components/custom-select.css
+++ b/src/Styles/components/custom-select.css
@@ -12,3 +12,9 @@ form .custom-select-wrapper {
     align-items: flex-start;
     width: 100%;
 }
+
+@media (min-width: 900px){
+    form .custom-select-wrapper {
+        width: 380px;
+    }
+}


### PR DESCRIPTION
## Problema a ser resolvido?

Mostrar valor da competência BNNC na tela de exibição dos recursos e ajustar responsividade do novo select


## O que foi feito para resolver o problema?

- Mapemento do novo campo dentro do `RESOURCE_FIELDS`
- Adição de media query para ajustar tamanho do select em telas maiores

## Descrição do impacto

Quebra na visualização dos recursos
Quebra visual no formulário

## Screenshots

Apenas se necessário

